### PR TITLE
Fix: Update deployment script to use 'built' directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           cp mume.macros.js deploy_dir/
           cp mume.menu.js deploy_dir/
           cp -r resources/ deploy_dir/
-          cp -r dist/ deploy_dir/
+          cp -r built/ deploy_dir/
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
The TypeScript compiler is configured to output to 'built/', but the deployment script was attempting to copy from 'dist/'. This commit corrects the path in the GitHub Actions workflow to 'built/', resolving the 'No such file or directory' error during deployment.